### PR TITLE
Note which SoC we mean by dragonboard

### DIFF
--- a/soc-boot-behaviour.rst
+++ b/soc-boot-behaviour.rst
@@ -12,8 +12,8 @@ Supposedly newer Raspberry Pis can handle GUID Partition Tables, but haven't fou
 
 https://github.com/raspberrypi/noobs/wiki/Standalone-partitioning-explained
 
-Dragonboard
------------
+Dragonboard (db410)
+-------------------
 
 GUID Partition Table with firmware loaded from specific partitions: ``hyp``, ``rpm``, ``sbl1``, ``tz``, ``aboot``, and ``cdt``.
 


### PR DESCRIPTION
Note that I'm not sure if this info is also true for db820, but I suspect it is, and if so we should probably re-headline to DB410 / DB820 and give Dragonboard as an example in the section itself.

Signed-off-by: Tom Rini <trini@konsulko.com>