### PR TITLE
Initial pass at i.MX and Allwinner sunxi notes

### DIFF
--- a/soc-boot-behaviour.rst
+++ b/soc-boot-behaviour.rst
@@ -20,3 +20,11 @@ GUID Partition Table with firmware loaded from specific partitions: ``hyp``, ``r
 HiKey
 -----
 GUID Partition Table on eMMC. Native partitioning on UFS. Firmware loaded from specific partitions: ``xloader``, ``fastboot``, ``nvme``, ``fw_lpm3``, ``trustfirmware``.
+
+i.MX (AArch32)
+--------------
+These families (such as i.MX6, i.MX7) load firmware found at the one kilobyte offset of an SD or eMMC device.
+
+Allwinner sunxi
+---------------
+These families (both 32 and 64bit) load firmware found at the 8 kilobyte offset of an SD or eMMC device.


### PR DESCRIPTION
- List i.MX (AArch32) values.  I don't know if these are correct for
  i.MX8 (AArch64) or not so I have left that out.
- Add Allwinner sunxi notes, and these are correct for both 32 and 64bit
  platforms currently.

Signed-off-by: Tom Rini <trini@konsulko.com>